### PR TITLE
updates license

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About blosc
 
 Home: https://github.com/Blosc/c-blosc
 
-Package license: Apache 2.0
+Package license: BSD 3-Clause License
 
 Feedstock license: BSD 3-Clause
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,3 +38,4 @@ about:
 extra:
   recipe-maintainers:
     - danielfrg
+    - FrancescElies

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,8 @@ test:
 
 about:
   home: https://github.com/Blosc/c-blosc
-  license: Apache 2.0
+  license: BSD 3-Clause License
+  license_file: LICENSES/BLOSC.txt
   summary: 'A blocking, shuffling and loss-less compression library that can be faster than `memcpy()`'
 
 extra:


### PR DESCRIPTION
Updates license to https://github.com/Blosc/c-blosc/blob/master/LICENSES/BLOSC.txt and rerender feedstock