### PR TITLE
Fix license

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About blosc
 
 Home: https://github.com/Blosc/c-blosc
 
-Package license: BSD 3-Clause License
+Package license: BSD 3-Clause
 
 Feedstock license: BSD 3-Clause
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ conda search blosc --channel conda-forge
 ```
 
 
-
 About conda-forge
 =================
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
 
 about:
   home: https://github.com/Blosc/c-blosc
-  license: BSD 3-Clause License
+  license: BSD 3-Clause
   license_file: LICENSES/BLOSC.txt
   summary: 'A blocking, shuffling and loss-less compression library that can be faster than `memcpy()`'
 


### PR DESCRIPTION
Drop `License` from the `license` metadata to make the linter happy.