### PR TITLE
Release 1.12.0 is out

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.9.2" %}
+{% set version = "1.12.0" %}
 
 package:
   name: blosc
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://github.com/Blosc/c-blosc/archive/v{{ version }}.tar.gz
-  sha256: 6349ab927705a451439b2e23ec5c3473f6b7e444e6d4aafaff76b789713e9fee
+  sha256: 77ea34f882189f87b68d9b25619462f914f61c8ae152ee5ee5e9971ea36661ec
 
 build:
-  number: 1
+  number: 0
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
Release 1.12.0 is out https://github.com/Blosc/c-blosc/releases