### PR TITLE
Build v1.14.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.14.0" %}
+{% set version = "1.14.3" %}
 
 package:
   name: blosc
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/Blosc/c-blosc/archive/v{{ version }}.tar.gz
-  sha256: 68b8c157beae5409e039ae266ad6c14b55a69a4899dba1f0df6c806a2f36360d
+  sha256: 7217659d8ef383999d90207a98c9a2555f7b46e10fa7d21ab5a1f92c861d18f7
   patches:
     ####################################################
     # Fix an issue with C89 compatibility.             #


### PR DESCRIPTION
This will (hopefully) also build the currently missing packages in the win-64 channel (#22), that breaks conda-forge pytables (conda-forge/pytables-feedstock#31)
