### PR TITLE
Rerender: new archs

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 75d98c752b8cf0d4a6380a3089d56523f175b0afa2d0cf724a1bd0a1a8f975a4
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('blosc') }}
 


### PR DESCRIPTION
Trying to rerender for the new architectures, especially aarch64, since the [`channeldata.json` issue](https://github.com/conda/conda-build/issues/3583) was [fixed](https://github.com/conda/conda-build/pull/3611) in `conda-build` [after we merged](https://github.com/conda-forge/blosc-feedstock/pull/36) the first build and causes problems [downstream](https://github.com/conda-forge/adios2-feedstock/pull/1) with run exports during linking.

Hm, interestingly, the [latest build](https://github.com/conda-forge/blosc-feedstock/pull/37) should have included this fix already...

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
