### PR TITLE
Fix SPDX Identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About blosc
 
 Home: https://github.com/Blosc/c-blosc
 
-Package license: BSD 3-Clause
+Package license: BSD-3-Clause
 
 Feedstock license: BSD 3-Clause
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ test:
 
 about:
   home: https://github.com/Blosc/c-blosc
-  license: BSD 3-Clause
+  license: BSD-3-Clause
   license_file: LICENSES/BLOSC.txt
   summary: A blocking, shuffling and loss-less compression library that can be faster than `memcpy()`
 


### PR DESCRIPTION
Fix the SPDX identifier (`BSD-3-Clause` in https://github.com/Blosc/c-blosc/blob/master/LICENSES/BLOSC.txt).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
